### PR TITLE
fix: remove SRI integrity hashes from same-origin assets

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
     <link rel="canonical" href="https://sauravbhattacharya001.github.io/sauravbhattacharya001/">
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
-    <link rel="stylesheet" href="style.css" integrity="sha384-r1IT7XwV3ObkDWsQbLdfrJ1gbSzCuHtQtFJa+yELJsTq8G7xrAedzP+YeffTUuqy" crossorigin="anonymous">
+    <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
@@ -169,6 +169,6 @@
     <p style="margin-top: 0.5rem;">© 2026 Saurav Bhattacharya</p>
 </footer>
 
-<script src="app.js" integrity="sha384-1KrHBtna/LN156ytDRmK0KZBdVDZkXSbFcONCjtCnL3LC0qVl77uqqr78PbKbp0d" crossorigin="anonymous"></script>
+<script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Removes SRI integrity attributes from same-origin \style.css\ and \pp.js\ references in \index.html\.

## Why

SRI hashes are designed for **cross-origin CDN resources** to protect against CDN compromise. For same-origin assets served from the same deployment, SRI adds no security value but creates a maintenance hazard: any change to \pp.js\ or \style.css\ silently breaks the live GitHub Pages site because the browser refuses to load resources with mismatched hashes.

The existing CSP \script-src 'self'\ already restricts scripts to same-origin, providing equivalent protection.

Fixes #13